### PR TITLE
Fix swift package path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,11 @@ let package = Package(
     targets: [
         .target(
             name: "BVSwift",
-            dependencies: []),
+            dependencies: [],
+            path: "BVSwift"),
         .testTarget(
             name: "BVSwiftTests",
-            dependencies: ["BVSwift"]),
+            dependencies: ["BVSwift"],
+            path: "BVSwiftTests"),
     ]
 )


### PR DESCRIPTION
## Description

Defines the source path the BVSwift and BVSwiftTests targets. Without this defined Swift Package Manager expects the source files to be found in a `Sources/BVSwift` directory. This should fix that issue and allow SPM to resolve and add the package as a dependency appropriately.

## Checklist

I validated that this corrects the issue adding the dependency in SPM using the branch on my fork.
