### PR TITLE
remove a withspace at the end of line 5. it makes xcode is unable to parse the file

### DIFF
--- a/Examples/BVSwiftDemo/BVSwiftDemo/Info.plist
+++ b/Examples/BVSwiftDemo/BVSwiftDemo/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>NSUserTrackingUsageDescription</key> 
+  <key>NSUserTrackingUsageDescription</key>
   <string>Your data will be used to provide you a better and personalized ad experience</string>
 	<key>ENV</key>
 	<string>$(ENV)</string>


### PR DESCRIPTION
… to parse the info.plist file

## Description

Please explain the changes you made here.

## Checklist

- [x] Code compiles correctly
- [x] Proper Xcode Markup comments are added to changes
- [x] Created tests which fail without the change (if applicable)
- [x] All tests passing
- [x] Validate that all example applications compile, run, and work (if applicable)
- [x] Extended the README, if necessary
