### PR TITLE
Add disabled IDFA SPM library variant

### DIFF
--- a/BVSwift/BVCommon/Utilities/BVFingerprint.swift
+++ b/BVSwift/BVCommon/Utilities/BVFingerprint.swift
@@ -55,13 +55,17 @@ internal class BVFingerprint {
     }
     
     func isAdvertisingTrackingEnabled() -> Bool {
-        
+
+        #if !DISABLE_BVSDK_IDFA
         if #available(iOS 14, *) {
             return ATTrackingManager.trackingAuthorizationStatus == .authorized
         }
         else {
             return ASIdentifierManager.shared().isAdvertisingTrackingEnabled
         }
+        #else
+        return false
+        #endif
     }
 }
 

--- a/BVSwiftNoIDFA
+++ b/BVSwiftNoIDFA
@@ -1,0 +1,1 @@
+BVSwift

--- a/BVSwiftTests/BVConversations/Display/BVReviewQueryTest.swift
+++ b/BVSwiftTests/BVConversations/Display/BVReviewQueryTest.swift
@@ -321,10 +321,14 @@ class BVReviewQueryTest: XCTestCase {
             XCTAssertNil(syndicationSource.contentLink)
             XCTAssertNotNil(syndicationSource.logoImageUrl)
         }
+
+        #if SWIFT_PACKAGE
+        let bundle = Bundle.module
+        #else
+        let bundle = Bundle(for: type(of: self))
+        #endif
         
-        let path =
-            Bundle(for: type(of: self))
-                .path(forResource: "testSyndicationSource", ofType: "json")!
+        let path = bundle.path(forResource: "testSyndicationSource", ofType: "json")!
         let url = URL(fileURLWithPath: path)
         guard let fileData = try? Data(contentsOf: url) else {
             XCTFail()

--- a/Package.swift
+++ b/Package.swift
@@ -9,16 +9,36 @@ let package = Package(
   products: [
     .library(
       name: "BVSwift",
-      targets: ["BVSwift"]),
+      targets: ["BVSwift"]
+    ),
+    .library(
+        name: "BVSwiftNoIDFA",
+        targets: ["BVSwiftNoIDFA"]
+    ),
   ],
   
   dependencies: [],
   
   targets: [
     .target(name: "BVSwift", path: "BVSwift", exclude: ["Support"]),
+    // current workaround to avoid exclusive path checks is to use a symlink:
+    // https://forums.swift.org/t/spm-shared-targets-files-use-case-whats-the-alternative/38888/4
+    // pitch with possible solution:
+    // https://forums.swift.org/t/pitch-mutually-exclusive-groups-of-targets/47518
+    .target(
+        name: "BVSwiftNoIDFA",
+        dependencies: [],
+        path: "BVSwiftNoIDFA",
+        exclude: ["Support"],
+        swiftSettings: [.define("DISABLE_BVSDK_IDFA")]
+    ),
     .testTarget(
       name: "BVSwiftTests",
       dependencies: ["BVSwift"],
-      path: "BVSwiftTests"),
+      path: "BVSwiftTests",
+      exclude: ["Info.plist"],
+      resources: [.process("MockData")]
+    )
+    
   ]
 )


### PR DESCRIPTION
## Description

On our project we currently import BVSwift via CocoaPods, passing in `DISABLE_BVSDK_IDFA` flag so that IDFA is not included in the library.

However, the current SPM set up doesn't allow this because any compile flags need to be passed in the target's `swiftSettings` parameter, and the default configuration is to have IDFA *enabled*, i.e. the flag _not_ set.

To make matters more complicated, if we simply create a new SPM target with the flag (and respective library product using it), SPM fails package validation with:

`error: target 'BVSwiftNoIDFA' has sources overlapping sources: ...`

This makes sense as SPM performs this check to ensure no duplicate paths can be included from different targets, in order to prevent duplicate symbols.

Nonetheless, there are scenarios (such as this one) where it's reasonable to allow multiple set ups for the same package, even if they have overlapping paths. And while SPM still doesn't allow this natively, we can "trick" it by using a symlink to the overlapped path:

https://forums.swift.org/t/spm-shared-targets-files-use-case-whats-the-alternative/38888/4

That's precisely what we've done here, by creating a new symlink `BVSwiftNoIDFA` that points to `BVSwift` folder, used by a new target and library with the same name. The caveat is that users can't import both `BVSwift` and `BVSwiftNoIDFA` simultaneously, as they'll get duplicate symbols.  For now, I think this is an acceptable tradeoff as it allows users that disable IDFA to import BVSwift via SPM.

For completeness' sake, I've created a pitch for an oficial solution to this problem which addresses the mentioned problems in a simple way:

https://forums.swift.org/t/pitch-mutually-exclusive-groups-of-targets/47518

## Changes

- Create new `BVSwiftNoIDFA` symlink that points to `BVSwift`.

- Create new `BVSwiftNoIDFA` SPM target, that sets the `DISABLE_BVSDK_IDFA` flag and uses the `BVSwiftNoIDFA` symlink.

- Create new `BVSwiftNoIDFA` SPM library product that includes the `BVSwiftNoIDFA` target.

- Add missing `#if !DISABLE_BVSDK_IDFA` check in `BVfingerprint.isAdvertisingTrackingEnabled()`.

- Make tests run via SPM (i.e. not crash due to missing resources.

## Notes ⚠️ 

Tests were already failing in `master`, and didn't update the `README` because this is pending review.

## Checklist

- [x] Code compiles correctly
- [x] Proper Xcode Markup comments are added to changes
- [x] Created tests which fail without the change (if applicable)
- [ ] All tests passing
- [x] Validate that all example applications compile, run, and work (if applicable)
- [ ] Extended the README, if necessary
