### PR TITLE
Fix compression quality set to 900%.

### DIFF
--- a/BVSwift/BVConversations/Model/BVPhoto.swift
+++ b/BVSwift/BVConversations/Model/BVPhoto.swift
@@ -97,7 +97,7 @@ public struct BVPhoto: BVSubmissionable {
     while BVPhoto.MaxImageBytes <= data.count {
       
       if let lossy: Data =
-        workingImage.jpegData(compressionQuality: 9.0) {
+        workingImage.jpegData(compressionQuality: 0.9) {
         data = lossy
       }
       


### PR DESCRIPTION
## Description

The current downscaling operations don't use the correct compression. This PR fixes that.

## Checklist

- [x] Code compiles correctly
- [x] Proper Xcode Markup comments are added to changes
- [x] Created tests which fail without the change (if applicable)
- [x] All tests passing
- [x] Validate that all example applications compile, run, and work (if applicable)
- [x] Extended the README, if necessary
