### PR TITLE
Fixed missing client key in Analytics whiteList

### DIFF
--- a/BVSwift/BVAnalytics/BVAnalyticsConstants.swift
+++ b/BVSwift/BVAnalytics/BVAnalyticsConstants.swift
@@ -48,6 +48,7 @@ internal struct BVAnalyticsConstants {
     "country",
     "currency",
     "items",
+    "client",
     "locale",
     "type",
     "label",


### PR DESCRIPTION
## Description

The `client` key was missing in the Analytics whitelist, causing the event to be consistently tagged as **PII**.

## Checklist

- [x] Code compiles correctly
- [x] Proper Xcode Markup comments are added to changes
- [x] Created tests which fail without the change (if applicable)
- [x] All tests passing
- [x] Validate that all example applications compile, run, and work (if applicable)
- [x] Extended the README, if necessary
